### PR TITLE
(fix) ensure that grabber pulls confounds file rather than metadata

### DIFF
--- a/run.py
+++ b/run.py
@@ -166,6 +166,7 @@ def main():
                 domains='derivatives',
                 suffix='regressors',
                 return_type='file',
+                extensions=['.tsv'],
                 **subquery)[0]
             inputs[sub]['tr'] = part.metadata.get('RepetitionTime')
 


### PR DESCRIPTION
In post-1.4.0 deployments, the grabber was pulling the confounds metadata file (`desc-confounds_regressors.json`) since it matched all queried fields and came first alphabetically, resulting in a processing error. Specifying the extension appears to have resolved the issue.